### PR TITLE
Replace gendered pronoun in README

### DIFF
--- a/README.html
+++ b/README.html
@@ -56,7 +56,7 @@
 <div id="outline-container-orgheadline3" class="outline-4">
 <h4 id="orgheadline3"><span class="section-number-4">1.1.3</span> Quotations</h4>
 <div class="outline-text-4" id="text-1-1-3">
-<p>"If one has been trying to bulk convert many quickly changing org-documents, he will appreciate the power and flexibility of this tool."<br />
+<p>"If one has been trying to bulk convert many quickly changing org-documents, [one] will appreciate the power and flexibility of this tool."<br />
 - <i>z27</i></p>
 <p>"orgmk is a wonderful tool, and, as far as I know, still unique."<br />
 - <i>Priyadarshan</i></p>

--- a/README.org
+++ b/README.org
@@ -40,8 +40,8 @@ documents.
 
 *** Quotations
 
-"If one has been trying to bulk convert many quickly changing org-documents, he
-will appreciate the power and flexibility of this tool." \\
+"If one has been trying to bulk convert many quickly changing org-documents,
+[one] will appreciate the power and flexibility of this tool." \\
 -- /z27/
 
 "orgmk is a wonderful tool, and, as far as I know, still unique." \\


### PR DESCRIPTION
I was happy to discover `orgmk` today as it's exactly the tool I've been looking for. However, I'd like to suggest replacing the gendered pronoun "he" in the readme with the more inclusive (and consistent) "one". Referring to generic users as "he", even in testimonials from Reddit, does contribute to an exclusionary environment for people who are not dudes, so I hope you'll consider incorporating this change.