### PR TITLE
orgmk: refresh package archive contents if missing

### DIFF
--- a/site-lisp/orgmk.el
+++ b/site-lisp/orgmk.el
@@ -35,7 +35,9 @@
   (require 'package)
   (add-to-list 'package-archives '("org" . "http://orgmode.org/elpa/"))
   (add-to-list 'package-archives '("melpa" . "http://melpa.milkbox.net/packages/"))
-  (package-initialize))
+  (package-initialize)
+  (unless package-archive-contents
+    (package-refresh-contents)))
 
 (unless (locate-library "ox")           ; trick to detect the presence of Org 8
   (ding)


### PR DESCRIPTION
For new installations of emacs (such as, say, a docker container), the package
contents are never initialized and htmlize cannot be installed. This patch
checks the package-archive-contents variable and refreshes as needed.