### PR TITLE
bin/orgmk-init: Allow users to provide flags in the call of emacs

### DIFF
--- a/bin/orgmk-init
+++ b/bin/orgmk-init
@@ -111,7 +111,7 @@ EMACS=emacs
 
 WHICH_EMACS=$(which $EMACS)
 EMACS_FLAGS="--eval \"(progn (message \\\"Launching $WHICH_EMACS...\\\") (message \\\"Emacs %s (%s)\\\" emacs-version system-type))\""
-EMACS_BATCH="emacs --batch -Q $EMACS_FLAGS"
-ORG_FLAGS=""
-ORGMK="$EMACS_BATCH $ORG_FLAGS --eval \"(message \\\"Loading ${ORGMK_EL}...\\\")\" -l $ORGMK_EL"
+EMACS_BATCH="emacs --batch $EMACS_FLAGS"
+[ "$ORGMK_FLAGS" ] || ORGMK_FLAGS=""
+ORGMK="$EMACS_BATCH $ORGMK_FLAGS --eval \"(message \\\"Loading ${ORGMK_EL}...\\\")\" -l $ORGMK_EL"
 ORGMK_UPDATE_FLAGS="-f org-update-all-dblocks -f org-table-iterate-buffer-tables --eval \"(write-file \\\"${FILE_SRC_UPDT##*/}\\\")\"" # base name


### PR DESCRIPTION
This commit introduces a mechanism for allowing users to provide flags
to the call of $EMACS_BATCH in bin/orgmk-init.  With this change, it
is possible to do calls like this:

    ORGMK_FLAGS="-u myusername" org2pdf input.org

The exemple above is quite handy, because the --batch option, which is
used in the call of emacs, prevents the personal initialization file
to be loaded.

The unused varible ORG_FLAGS in orgmk-init is changed into
ORGMK_FLAGS, because this is a more explicit name.  This is only a
sugegstion and perhaps another better solution could be provided.  The
essence of this commit is to allow an environment variable (in
occurrence, ORGMK_FLAGS) to sneak into orgmk-init.