### PR TITLE
Make the targets for orgmk.conf and orgmk-stow-orgmk.mk not phony

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,16 +36,14 @@ ORGMK_MAKE_RUN=orgmk
 ## MAKE
 
 # Ensure `all' is the default target
-all: orgmk-system-config orgmk-stow-mk  # Create Orgmk system files
+all: bin/$(ORGMK_SYSTEM_CONFIG) bin/$(ORGMK_MAKE_SETUP)  # Create Orgmk system files
 
-.PHONY: orgmk-system-config
-orgmk-system-config:                    # Create file with location of `orgmk.el'
+bin/$(ORGMK_SYSTEM_CONFIG):                    # Create file with location of `orgmk.el'
 	@echo "Generating system-wide configuration file..."
 	echo "ORGMK_EL=$(ORGMK_EL)" > bin/$(ORGMK_SYSTEM_CONFIG)
 	@echo
 
-.PHONY: orgmk-stow-mk
-orgmk-stow-mk:                          # Create core file for `orgmk'
+bin/$(ORGMK_MAKE_SETUP):                          # Create core file for `orgmk'
 	@echo "Generating setup file..."
 	echo "#!/bin/sh" > bin/$(ORGMK_MAKE_SETUP)
 	echo "ln -f -s $(PWD)/bin/orgmk.mk orgmk.mk" >> bin/$(ORGMK_MAKE_SETUP)

--- a/README.org
+++ b/README.org
@@ -277,16 +277,14 @@ ORGMK_MAKE_RUN=orgmk
 ## MAKE
 
 # Ensure `all' is the default target
-all: orgmk-system-config orgmk-stow-mk  # Create Orgmk system files
+all: bin/$(ORGMK_SYSTEM_CONFIG) bin/$(ORGMK_MAKE_SETUP)  # Create Orgmk system files
 
-.PHONY: orgmk-system-config
-orgmk-system-config:                    # Create file with location of `orgmk.el'
+bin/$(ORGMK_SYSTEM_CONFIG):                    # Create file with location of `orgmk.el'
 	@echo "Generating system-wide configuration file..."
 	echo "ORGMK_EL=$(ORGMK_EL)" > bin/$(ORGMK_SYSTEM_CONFIG)
 	@echo
 
-.PHONY: orgmk-stow-mk
-orgmk-stow-mk:                          # Create core file for `orgmk'
+bin/$(ORGMK_MAKE_SETUP):                          # Create core file for `orgmk'
 	@echo "Generating setup file..."
 	echo "#!/bin/sh" > bin/$(ORGMK_MAKE_SETUP)
 	echo "ln -f -s $(PWD)/bin/orgmk.mk orgmk.mk" >> bin/$(ORGMK_MAKE_SETUP)


### PR DESCRIPTION
This prevents "sudo make install" from giving this error when using
NFS with root squash enabled:
```
/bin/sh: 1: cannot create bin/orgmk.conf: Permission denied
Makefile:43: recipe for target 'orgmk-system-config' failed
make: *** [orgmk-system-config] Error 2
```