### PR TITLE
Use /bin/bash for orgmk-update-src-check-diff

### DIFF
--- a/README.org
+++ b/README.org
@@ -630,7 +630,7 @@ orgmk-update-src-check-diff "$FILE_SRC_ORIG" "$FILE_SRC_UPDT"
 
 ** Orgmk-update-src-check-diff
    :PROPERTIES:
-   :header-args+: :shebang "#!/bin/sh\n" :tangle bin/orgmk-update-src-check-diff
+   :header-args+: :shebang "#!/bin/bash\n" :tangle bin/orgmk-update-src-check-diff
    :END:
 
 Check whether dynamic blocks and tables have been updated, and (if yes) propose

--- a/bin/orgmk-update-src-check-diff
+++ b/bin/orgmk-update-src-check-diff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ask () {
     while true; do


### PR DESCRIPTION
This fixes orgmk-update-src-check-diff that will give an error when
/bin/sh isn't bash:
```
/usr/local/bin/orgmk-update-src-check-diff: 46: /usr/local/bin/orgmk-update-src-check-diff: [[: not found
/usr/local/bin/orgmk-update-src-check-diff: 50: /usr/local/bin/orgmk-update-src-check-diff: [[: not found
```