### PR TITLE
Add ability for orgmk to use xelatex or lualatex

### DIFF
--- a/README.org
+++ b/README.org
@@ -1377,49 +1377,49 @@ difference in the resulting HTML file.
 *************** END
 
 #+begin_src emacs-lisp
-(when (require 'ox-latex)
+  (when (require 'ox-latex)
 
-  ;; ;; This is disturbing when calling `org2html'.
-  ;; (when (executable-find "latexmk")
-  ;;   (message "%s" (shell-command-to-string "latexmk --version")))
+    ;; ;; This is disturbing when calling `org2html'.
+    ;; (when (executable-find "latexmk")
+    ;;   (message "%s" (shell-command-to-string "latexmk --version")))
 
-  (setq org-latex-pdf-process
-        (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
-            ;; use Latexmk (if installed with LaTeX)
+    (setq org-latex-pdf-process
+          (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
+              ;; use Latexmk (if installed with LaTeX)
+              (if (executable-find "latexmk")
+                  '("latexmk -CF -%latex $(cygpath -m %f) && latexmk -c")
+                '("%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
+                  "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
+                  "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
             (if (executable-find "latexmk")
-                '("latexmk -CF -pdf $(cygpath -m %f) && latexmk -c")
-              '("pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
-                "pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
-                "pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
-          (if (executable-find "latexmk")
-              '("latexmk -CF -pdf %f && latexmk -c")
-            '("pdflatex -interaction=nonstopmode -output-directory=%o %f"
-              "pdflatex -interaction=nonstopmode -output-directory=%o %f"
-              "pdflatex -interaction=nonstopmode -output-directory=%o %f"))))
+                '("latexmk -CF -%latex %f && latexmk -c")
+              '("%latex -interaction=nonstopmode -output-directory=%o %f"
+                "%latex -interaction=nonstopmode -output-directory=%o %f"
+                "%latex -interaction=nonstopmode -output-directory=%o %f"))))
 
-  (message "LaTeX command: %S" org-latex-pdf-process)
+    (message "LaTeX command: %S" org-latex-pdf-process)
+  
+    ;; tell org to use `listings' (instead of `verbatim') for source code
+    (setq org-latex-listings t)
 
-  ;; tell org to use `listings' (instead of `verbatim') for source code
-  (setq org-latex-listings t)
+    ;; default packages to be inserted in the header
+    ;; include the `listings' package for fontified source code
+    (add-to-list 'org-latex-packages-alist '("" "listings") t)
 
-  ;; default packages to be inserted in the header
-  ;; include the `listings' package for fontified source code
-  (add-to-list 'org-latex-packages-alist '("" "listings") t)
+    ;; include the `xcolor' package for colored source code
+    (add-to-list 'org-latex-packages-alist '("" "xcolor") t)
 
-  ;; include the `xcolor' package for colored source code
-  (add-to-list 'org-latex-packages-alist '("" "xcolor") t)
+    ;; include the `babel' package for language-specific hyphenation and
+    ;; typography
+    (add-to-list 'org-latex-packages-alist '("english" "babel") t)
 
-  ;; include the `babel' package for language-specific hyphenation and
-  ;; typography
-  (add-to-list 'org-latex-packages-alist '("english" "babel") t)
+    ;; default position for LaTeX figures
+    (setq org-latex-default-figure-position "!htbp")
 
-  ;; default position for LaTeX figures
-  (setq org-latex-default-figure-position "!htbp")
-
-  (defun org-latex-export-body-only-to-latex ()
-    "Export only code between \"\begin{document}\" and \"\end{document}\" to a LaTeX file."
-    (interactive)
-    (org-latex-export-to-latex nil nil nil t)))
+    (defun org-latex-export-body-only-to-latex ()
+      "Export only code between \"\begin{document}\" and \"\end{document}\" to a LaTeX file."
+      (interactive)
+      (org-latex-export-to-latex nil nil nil t)))
 #+end_src
 
 ** Extra customization files

--- a/README.org
+++ b/README.org
@@ -1387,12 +1387,12 @@ difference in the resulting HTML file.
           (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
               ;; use Latexmk (if installed with LaTeX)
               (if (executable-find "latexmk")
-                  '("latexmk -CF -%latex $(cygpath -m %f) && latexmk -c")
+                  '("latexmk -CF -%latex -norc $(cygpath -m %f) && latexmk -c")
                 '("%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
                   "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
                   "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
             (if (executable-find "latexmk")
-                '("latexmk -CF -%latex %f && latexmk -c")
+                '("latexmk -CF -%latex -norc %f && latexmk -c")
               '("%latex -interaction=nonstopmode -output-directory=%o %f"
                 "%latex -interaction=nonstopmode -output-directory=%o %f"
                 "%latex -interaction=nonstopmode -output-directory=%o %f"))))

--- a/README.org
+++ b/README.org
@@ -1383,6 +1383,10 @@ difference in the resulting HTML file.
     ;; (when (executable-find "latexmk")
     ;;   (message "%s" (shell-command-to-string "latexmk --version")))
 
+    ;; remove grffile from default packages, as it is depricated (usage included in normal graphicx),
+    ;; and causes xelatex and lualatex to fail when including graphics
+    (delete (rassoc '("grffile" t) org-latex-default-packages-alist) org-latex-default-packages-alist)
+
     (setq org-latex-pdf-process
           (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
               ;; use Latexmk (if installed with LaTeX)

--- a/site-lisp/orgmk.el
+++ b/site-lisp/orgmk.el
@@ -178,6 +178,10 @@
   ;; (when (executable-find "latexmk")
   ;;   (message "%s" (shell-command-to-string "latexmk --version")))
 
+  ;; remove grffile from default packages, as it is depricated (usage included in normal graphicx),
+  ;; and causes xelatex and lualatex to fail when including graphics
+  (delete (rassoc '("grffile" t) org-latex-default-packages-alist) org-latex-default-packages-alist)
+
   (setq org-latex-pdf-process
         (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
             ;; use Latexmk (if installed with LaTeX)

--- a/site-lisp/orgmk.el
+++ b/site-lisp/orgmk.el
@@ -182,15 +182,15 @@
         (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
             ;; use Latexmk (if installed with LaTeX)
             (if (executable-find "latexmk")
-                '("latexmk -CF -pdf $(cygpath -m %f) && latexmk -c")
-              '("pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
-                "pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
-                "pdflatex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
+                '("latexmk -CF -%latex $(cygpath -m %f) && latexmk -c")
+              '("%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
+                "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
+                "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
           (if (executable-find "latexmk")
-              '("latexmk -CF -pdf %f && latexmk -c")
-            '("pdflatex -interaction=nonstopmode -output-directory=%o %f"
-              "pdflatex -interaction=nonstopmode -output-directory=%o %f"
-              "pdflatex -interaction=nonstopmode -output-directory=%o %f"))))
+              '("latexmk -CF -%latex %f && latexmk -c")
+            '("%latex -interaction=nonstopmode -output-directory=%o %f"
+              "%latex -interaction=nonstopmode -output-directory=%o %f"
+              "%latex -interaction=nonstopmode -output-directory=%o %f"))))
 
   (message "LaTeX command: %S" org-latex-pdf-process)
 

--- a/site-lisp/orgmk.el
+++ b/site-lisp/orgmk.el
@@ -182,12 +182,12 @@
         (if (eq system-type 'cygwin) ;; running a Cygwin version of Emacs
             ;; use Latexmk (if installed with LaTeX)
             (if (executable-find "latexmk")
-                '("latexmk -CF -%latex $(cygpath -m %f) && latexmk -c")
+                '("latexmk -CF -%latex -norc $(cygpath -m %f) && latexmk -c")
               '("%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
                 "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"
                 "%latex -interaction=nonstopmode -output-directory=%o $(cygpath -m %f)"))
           (if (executable-find "latexmk")
-              '("latexmk -CF -%latex %f && latexmk -c")
+              '("latexmk -CF -%latex -norc %f && latexmk -c")
             '("%latex -interaction=nonstopmode -output-directory=%o %f"
               "%latex -interaction=nonstopmode -output-directory=%o %f"
               "%latex -interaction=nonstopmode -output-directory=%o %f"))))


### PR DESCRIPTION
Add ability for `orgmk` to use `xelatex` or `lualatex` by respecting `#+latex_compiler` variable and removing the deprecated `grffile` package from defaults that make those crash. The full functionality is included bug-free in modern versions of `graphicx`, which is included in `org-latex-default-package-alist` already.